### PR TITLE
Mark Kadas as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
This application relies on an outdated runtime that was marked as end-of-life (EOL) two years ago.

https://github.com/flathub/com.sourcepole.kadas/issues/10